### PR TITLE
Port the simple mode over to Wry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,9 +176,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a30da5c5f2d5e72842e00bcb57657162cdabef0931f40e2deb9b4140440cecd"
+checksum = "15c4c2c83f81532e5845a733998b6971faca23490340a418e9b72a3ec9de12ea"
 
 [[package]]
 name = "anstyle-parse"
@@ -674,9 +674,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.3.23"
+version = "4.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03aef18ddf7d879c15ce20f04826ef8418101c7e528014c3eeea13321047dca3"
+checksum = "fb690e81c7840c0d7aade59f242ea3b41b9bc27bcd5997890e7702ae4b32e487"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -685,9 +685,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.3.23"
+version = "4.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ce6fffb678c9b80a70b6b6de0aad31df727623a70fd9a842c30cd573e2fa98"
+checksum = "5ed2e96bc16d8d740f6f48d663eddf4b8a0983e79210fd55479b7bcd0a69860e"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1173,9 +1173,9 @@ dependencies = [
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.32"
+version = "0.8.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
+checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
 dependencies = [
  "cfg-if",
 ]
@@ -2317,14 +2317,17 @@ version = "0.1.0"
 dependencies = [
  "camino",
  "clap",
- "eframe",
- "egui",
+ "http",
  "log",
  "millenium-core",
+ "muda",
  "pretty_assertions",
  "rfd",
  "simplelog",
+ "tao",
+ "thiserror",
  "url",
+ "wry",
 ]
 
 [[package]]
@@ -3294,18 +3297,18 @@ checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
 
 [[package]]
 name = "serde"
-version = "1.0.185"
+version = "1.0.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be9b6f69f1dfd54c3b568ffa45c310d6973a5e5148fd40cf515acaf38cf5bc31"
+checksum = "9f5db24220c009de9bd45e69fb2938f4b6d2df856aa9304ce377b3180f83b7c1"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.185"
+version = "1.0.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc59dfdcbad1437773485e0367fea4b090a2e0a16d9ffc46af47764536a298ec"
+checksum = "5ad697f7e0b65af4983a4ce8f56ed5b357e8d3c36651bf6a7e13639c17b8e670"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4724,9 +4727,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d09770118a7eb1ccaf4a594a221334119a44a814fcb0d31c5b85e83e97227a97"
+checksum = "7c2e3184b9c4e92ad5167ca73039d0c42476302ab603e2fec4487511f38ccefc"
 dependencies = [
  "memchr",
 ]

--- a/millenium-core/src/player/audio.rs
+++ b/millenium-core/src/player/audio.rs
@@ -33,7 +33,7 @@ use symphonia_core::audio::{
 use symphonia_core::sample::Sample as SymphoniaSample;
 
 const PREFERRED_SAMPLE_RATE: SampleRate = SampleRate(44100);
-const DESIRED_QUEUE_LENGTH: u64 = 50 * 44100 / 1000; // 50ms
+const DESIRED_QUEUE_LENGTH: u64 = 100 * 44100 / 1000; // 100ms
 
 #[derive(Debug, thiserror::Error)]
 pub enum AudioDeviceError {

--- a/millenium-desktop/Cargo.toml
+++ b/millenium-desktop/Cargo.toml
@@ -24,13 +24,18 @@ publish = false
 [dependencies]
 camino = "1.1.6"
 clap = { version = "4.3.21", default-features = false, features = ["std", "help", "usage"] }
-eframe = "0.22.0"
-egui = { version = "0.22.0", features = ["extra_debug_asserts", "log"] }
+http = "0.2.9"
 log = "0.4.20"
 millenium-core = { path = "../millenium-core" }
 rfd = "0.11.4"
 simplelog = "0.12.1"
+tao = "0.22.2"
+thiserror = "1.0.47"
 url = "2.4.0"
+wry = "0.31.1"
 
 [dev-dependencies]
 pretty_assertions = "1.4.0"
+
+[target.'cfg(target_os = "macos")'.dependencies]
+muda = "0.8.5"

--- a/millenium-desktop/src/error.rs
+++ b/millenium-desktop/src/error.rs
@@ -1,0 +1,91 @@
+// This file is part of Millenium Player.
+// Copyright (C) 2023 John DiSanti.
+//
+// Millenium Player is free software: you can redistribute it and/or modify it under the terms of
+// the GNU General Public License as published by the Free Software Foundation, either version 3 of
+// the License, or (at your option) any later version.
+//
+// Millenium Player is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+// without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+// the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with Millenium Player.
+// If not, see <https://www.gnu.org/licenses/>.
+
+use std::borrow::Cow;
+use std::error::Error as StdError;
+use std::fmt;
+
+use millenium_core::player::PlayerThreadError;
+
+/// A boxed error that is send and sync.
+pub type BoxError = Box<dyn StdError + Send + Sync>;
+
+/// A fatal error that should be reported to the user.
+#[derive(Debug)]
+pub struct FatalError {
+    message: Option<Cow<'static, str>>,
+    source: Option<BoxError>,
+}
+
+#[allow(dead_code)]
+impl FatalError {
+    /// Creates a new fatal error with a source.
+    pub fn new(what: impl Into<Cow<'static, str>>, source: impl Into<BoxError>) -> Self {
+        Self {
+            message: Some(what.into()),
+            source: Some(source.into()),
+        }
+    }
+
+    /// Creates a new fatal error from a message.
+    pub fn msg(what: impl Into<Cow<'static, str>>) -> Self {
+        Self {
+            message: Some(what.into()),
+            source: None,
+        }
+    }
+
+    /// Creates a new fatal error with a source only.
+    pub fn source_only(source: impl Into<BoxError>) -> Self {
+        Self {
+            message: None,
+            source: Some(source.into()),
+        }
+    }
+}
+
+impl StdError for FatalError {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        self.source.as_ref().map(|e| e.as_ref() as _)
+    }
+}
+
+impl fmt::Display for FatalError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if let Some(message) = &self.message {
+            write!(f, "{}", message)?;
+        }
+        if let Some(source) = &self.source {
+            write!(
+                f,
+                "{}{}",
+                if self.message.is_some() { ": " } else { "" },
+                source
+            )?;
+        }
+        Ok(())
+    }
+}
+
+impl From<clap::Error> for FatalError {
+    fn from(err: clap::Error) -> Self {
+        Self::source_only(err)
+    }
+}
+
+impl From<PlayerThreadError> for FatalError {
+    fn from(err: PlayerThreadError) -> Self {
+        Self::source_only(err)
+    }
+}

--- a/millenium-desktop/src/main.rs
+++ b/millenium-desktop/src/main.rs
@@ -12,19 +12,24 @@
 // You should have received a copy of the GNU General Public License along with Millenium Player.
 // If not, see <https://www.gnu.org/licenses/>.
 
+use crate::error::FatalError;
 use std::env;
-use std::error::Error as StdError;
+
+const APP_TITLE: &str = "Millenium Player";
 
 /// Command-line argument parsing.
 mod args;
 
+/// Common error types.
+mod error;
+
 /// Simple audio player mode with no library management features
 mod simple_mode;
 
-fn do_main() -> Result<(), Box<dyn StdError>> {
+fn do_main() -> Result<(), FatalError> {
     let mode = args::parse(env::args_os())?;
-    let result = match mode {
-        args::Mode::Simple { locations } => simple_mode::SimpleMode::run(&locations),
+    match mode {
+        args::Mode::Simple { locations } => simple_mode::SimpleModeUi::new(&locations)?.run(),
         args::Mode::Library {
             storage_path,
             audio_path,
@@ -32,9 +37,7 @@ fn do_main() -> Result<(), Box<dyn StdError>> {
             let (_, _) = (storage_path, audio_path);
             unimplemented!("library mode hasn't been implemented yet")
         }
-    };
-    result?;
-    Ok(())
+    }
 }
 
 fn main() {

--- a/millenium-desktop/src/simple_mode.rs
+++ b/millenium-desktop/src/simple_mode.rs
@@ -12,6 +12,7 @@
 // You should have received a copy of the GNU General Public License along with Millenium Player.
 // If not, see <https://www.gnu.org/licenses/>.
 
+use crate::{error::FatalError, APP_TITLE};
 use millenium_core::{
     location::Location,
     player::{
@@ -20,33 +21,41 @@ use millenium_core::{
     },
 };
 use std::{
-    error::Error as StdError,
+    borrow::Cow,
     sync::mpsc::{self, Receiver},
+    time::{Duration, Instant},
 };
-
-enum State {
-    NoLocations,
-    PlayStream(PlayStreamState),
-}
-
-#[derive(Default)]
-struct PlayStreamState {}
 
 struct Playlist {
     locations: Vec<Location>,
     current: Option<usize>,
 }
 
-pub struct SimpleMode {
+pub struct SimpleModeUi {
+    /// MacOS has the special "always at the top" menu bar that needs to get populated.
+    /// Menus aren't needed for the other OSes.
+    #[cfg(target_os = "macos")]
+    _osx_app_menu: OsxAppMenu,
+
+    _main_web_view: wry::webview::WebView,
+    event_loop: Option<tao::event_loop::EventLoop<()>>,
+
     player: Option<PlayerThreadHandle>,
     // TODO receive and handle messages from player thread
     _player_receiver: Receiver<FromPlayerMessage>,
     _playlist: Playlist,
-    _state: State,
 }
 
-impl SimpleMode {
-    fn new(locations: &[Location]) -> Result<Self, Box<dyn StdError>> {
+impl SimpleModeUi {
+    pub fn new(locations: &[Location]) -> Result<Self, FatalError> {
+        let event_loop = tao::event_loop::EventLoop::new();
+        let main_window = tao::window::WindowBuilder::new()
+            .with_title(APP_TITLE)
+            .with_decorations(true)
+            .build(&event_loop)
+            .map_err(|err| FatalError::new("failed to create window", err))?;
+        let main_web_view = create_webview(main_window)?;
+
         let filtered_locations: Vec<Location> = locations
             .iter()
             .cloned()
@@ -67,69 +76,155 @@ impl SimpleMode {
             current: filtered_locations.get(0).map(|_| Some(0)).unwrap_or(None),
             locations: filtered_locations,
         };
-        let state = if let Some(index) = playlist.current {
+        if let Some(index) = playlist.current {
             player.send(ToPlayerMessage::LoadAndPlayLocation(
                 playlist.locations[index].clone(),
             ))?;
-            State::PlayStream(Default::default())
-        } else {
-            State::NoLocations
-        };
+        }
+
         Ok(Self {
+            #[cfg(target_os = "macos")]
+            _osx_app_menu: OsxAppMenu::new()?,
+
+            _main_web_view: main_web_view,
+            event_loop: Some(event_loop),
+
             player: Some(player),
             _player_receiver: player_receiver,
             _playlist: playlist,
-            _state: state,
         })
     }
 
-    pub fn run(locations: &[Location]) -> Result<(), Box<dyn StdError>> {
-        let native_options = eframe::NativeOptions {
-            app_id: Some("millenium-player".into()),
-            drag_and_drop_support: true,
-            resizable: false,
-            ..Default::default()
-        };
-        let app = Box::new(Self::new(locations)?);
-        eframe::run_native(
-            "Millenium Player",
-            native_options,
-            Box::new(move |_creation_context| app),
-        )?;
-        Ok(())
+    pub fn run(mut self) -> ! {
+        use tao::event::{Event, WindowEvent};
+        use tao::event_loop::ControlFlow;
+
+        let event_loop = self.event_loop.take().expect("event loop");
+        event_loop.run(move |event, _, control_flow| {
+            *control_flow = ControlFlow::WaitUntil(Instant::now() + Duration::from_millis(100));
+
+            match event {
+                Event::LoopDestroyed => {
+                    if let Some(player) = self.player.take() {
+                        let _ = player.send(ToPlayerMessage::Quit);
+                        if let Err(err) = player.join() {
+                            log::error!("{err}");
+                        }
+                    }
+                }
+                Event::WindowEvent {
+                    event: WindowEvent::CloseRequested,
+                    ..
+                } => *control_flow = ControlFlow::Exit,
+
+                _ => (),
+            }
+
+            if let Err(err) = self.healthcheck() {
+                log::error!("{err}");
+                rfd::MessageDialog::new()
+                    .set_level(rfd::MessageLevel::Error)
+                    .set_title("Fatal error")
+                    .set_description(&format!("{APP_TITLE} had a fatal error:\n{err}"))
+                    .show();
+                *control_flow = ControlFlow::ExitWithCode(1);
+            }
+        });
     }
 
-    fn healthcheck(&mut self, frame: &mut eframe::Frame) {
-        match self.player.take().unwrap().healthcheck() {
-            Ok(player) => {
-                self.player = Some(player);
-            }
-            Err(err) => {
-                // TODO: display error
-                log::error!("{err}");
-                frame.close();
+    fn healthcheck(&mut self) -> Result<(), FatalError> {
+        if let Some(player) = self.player.take() {
+            match player.healthcheck() {
+                Ok(player) => self.player = Some(player),
+                Err(err) => return Err(err.into()),
             }
         }
+        Ok(())
     }
 }
 
-impl eframe::App for SimpleMode {
-    fn update(&mut self, _ctx: &egui::Context, frame: &mut eframe::Frame) {
-        self.healthcheck(frame);
-    }
+#[cfg(target_os = "macos")]
+struct OsxAppMenu {
+    _menu: muda::Menu,
+}
 
-    fn on_close_event(&mut self) -> bool {
-        if let Some(player) = self.player.as_ref() {
-            let _ = player.send(ToPlayerMessage::Quit);
-        }
-        true
-    }
+#[cfg(target_os = "macos")]
+impl OsxAppMenu {
+    fn new() -> Result<Self, FatalError> {
+        use muda::{AboutMetadata, Menu, PredefinedMenuItem, Submenu};
 
-    fn on_exit(&mut self, _gl: Option<&eframe::glow::Context>) {
-        if let Some(player) = self.player.take() {
-            if let Err(err) = player.join() {
-                log::error!("{err}");
-            }
-        }
+        let menu = Menu::new();
+
+        let app_menu = Submenu::new(APP_TITLE, true);
+        app_menu
+            .append_items(&[
+                &PredefinedMenuItem::about(None, Some(AboutMetadata::default())),
+                &PredefinedMenuItem::separator(),
+                &PredefinedMenuItem::services(None),
+                &PredefinedMenuItem::separator(),
+                &PredefinedMenuItem::separator(),
+                &PredefinedMenuItem::quit(None),
+            ])
+            .unwrap();
+
+        let window_menu = Submenu::new("Window", true);
+        window_menu
+            .append(&PredefinedMenuItem::minimize(None))
+            .unwrap();
+
+        menu.append_items(&[&app_menu, &window_menu]).unwrap();
+
+        menu.init_for_nsapp();
+        window_menu.set_as_windows_menu_for_nsapp();
+        Ok(Self { _menu: menu })
     }
+}
+
+fn create_webview(window: tao::window::Window) -> Result<wry::webview::WebView, FatalError> {
+    let webview = wry::webview::WebViewBuilder::new(window)
+        .map_err(|err| FatalError::new("failed to create web view", err))?
+        .with_custom_protocol("internal".into(), move |request| {
+            let path = request.uri().path();
+            let response: http::Response<String> = match path {
+                "/index.html" => {
+                    let html = r#"
+                        <html>
+                        <body style="color:#FFF;background-color:rgba(1, 1, 1, 1);">
+                            <h1>TODO</h1>
+                            <button onclick="window.ipc.postMessage('test IPC message')">Test IPC</button>
+                            <div id="testnum"></div>
+                            <script>
+                                function set_number(number) {
+                                    document.getElementById("testnum").innerHTML = number;
+                                }
+                            </script>
+                        </body>
+                        </html>
+                        "#;
+                    http::Response::builder()
+                        .status(200)
+                        .body(html.into())
+                        .unwrap()
+                }
+                _ => http::Response::builder()
+                    .status(404)
+                    .body("Not Found".into())
+                    .unwrap(),
+            };
+            Ok(response.map(|b| Cow::Owned(b.into_bytes())))
+        })
+        .with_ipc_handler(|_window, message| {
+            dbg!(message);
+        })
+        .with_url("internal://localhost/index.html")
+        .map_err(|err| FatalError::new("failed to set web view URL", err))?
+        .with_file_drop_handler(|_window, event| {
+            dbg!(event);
+            true
+        })
+        .with_transparent(true)
+        .with_visible(false)
+        .build()
+        .map_err(|err| FatalError::new("failed to create web view", err))?;
+    Ok(webview)
 }


### PR DESCRIPTION
This PR replaces egui with Wry in the simple mode, which makes the fatal error dialog actually work on MacOS.