### PR TITLE
Fix audio playback on Linux

### DIFF
--- a/core/src/audio/device.rs
+++ b/core/src/audio/device.rs
@@ -40,7 +40,7 @@ use std::{
 };
 
 const PREFERRED_SAMPLE_RATES: &[u32] = &[48000, 44100, 88200, 96000];
-const DESIRED_BUFFER_LENGTH: Duration = Duration::from_millis(100);
+const DESIRED_BUFFER_LENGTH: Duration = Duration::from_millis(500);
 
 #[derive(Debug, thiserror::Error)]
 pub enum AudioDeviceError {

--- a/core/src/player/state.rs
+++ b/core/src/player/state.rs
@@ -326,7 +326,7 @@ fn queue_chunks(
                             Some(resources.device.create_sink(sample_rate, channels));
                     }
                     let sink = resources.current_sink.as_ref().unwrap();
-                    sink.queue(chunk);
+                    sink.queue(&chunk);
                 }
             }
             Ok(None) => {

--- a/core/src/player/waveform.rs
+++ b/core/src/player/waveform.rs
@@ -197,7 +197,10 @@ impl<const BIN_COUNT: usize> SpectrumCalculator<BIN_COUNT> {
         debug_assert!(source.channel_count() > 0);
         debug_assert_eq!(self.sample_rate, source.sample_rate());
 
-        let source_mono = source.clone().remix(1);
+        // TODO: eliminate the clone here by keeping a buffer around and reusing it
+        let mut source_mono = source.clone();
+        source_mono.remix_in_place(1);
+
         self.sample_buffer
             .extend(source_mono.channel(0).iter().copied());
         if self.sample_buffer.len() > self.required_samples {


### PR DESCRIPTION
On Linux, audio playback was slow and choppy. Profiling revealed resampling was taking a lot of time, so that was switched to a synchronous `FixedIn` resampler, which is a lot faster than the previous one. In addition, many memory allocations were eliminated by reusing source buffers and doing as much as possible in-place.

Further optimization is possible, but this paired with increasing the buffer size has eliminated the choppiness. The flamegraph now shows the UI taking more CPU time than the player thread.

There are still other significant issues on Linux after this change.